### PR TITLE
Prevent OOM about commented row

### DIFF
--- a/src/usr/share/alternc/panel/class/m_nss.php
+++ b/src/usr/share/alternc/panel/class/m_nss.php
@@ -79,19 +79,8 @@ class m_nss
         $this->shadow = $lines;
     }
 
-    public function update_files()
+    protected function write_content($file, $file_bck, $content_new)
     {
-        $this->define_files();
-        $this->update_group_file();
-        $this->update_passwd_file();
-        $this->update_shadow_file();
-    }
-
-
-    protected function update_group_file()
-    {
-        $file = $this->dir_extrausers . "group";
-        $file_bck = $this->dir_backup . "group";
         $content_lines = false;
         if (file_exists($file)) {
             $content_lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
@@ -104,60 +93,43 @@ class m_nss
             $content_lines_bck = file($file_bck, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
             $content_lines = array_diff($content_lines, $content_lines_bck);
         }
-        $content_lines = array_merge($content_lines, $this->group);
+        $content_lines = array_merge($content_lines, $content_new);
         $content = implode("\n", $content_lines);
         $content_bck = implode("\n", $this->group);
 
-        $this->write_file($file_bck, $content_bck);
-        return $this->write_file($file, $content);
+        return $this->write_file($file_bck, $content_bck) && $this->write_file($file, $content);
+    }
+
+    public function update_files()
+    {
+        $this->define_files();
+        $this->update_group_file();
+        $this->update_passwd_file();
+        $this->update_shadow_file();
+    }
+
+    protected function update_group_file()
+    {
+        $file = $this->dir_extrausers . "group";
+        $file_bck = $this->dir_backup . "group";
+
+        return $this->write_content($file, $file_bck, $this->group);
     }
 
     protected function update_passwd_file()
     {
         $file = $this->dir_extrausers . "passwd";
         $file_bck = $this->dir_backup . "passwd";
-        $content_lines = false;
-        if (file_exists($file)) {
-            $content_lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-        }
 
-        if (!$content_lines) {
-            $content_lines = array();
-        }
-        if (file_exists($file_bck)) {
-            $content_lines_bck = file($file_bck, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-            $content_lines = array_diff($content_lines, $content_lines_bck);
-        }
-        $content_lines = array_merge($content_lines, $this->passwd);
-        $content = implode("\n", $content_lines);
-        $content_bck = implode("\n", $this->passwd);
-
-        $this->write_file($file_bck, $content_bck);
-        return $this->write_file($file, $content);
+        return $this->write_content($file, $file_bck, $this->passwd);
     }
 
     protected function update_shadow_file()
     {
         $file = $this->dir_extrausers . "shadow";
         $file_bck = $this->dir_backup . "shadow";
-        $content_lines = false;
-        if (file_exists($file)) {
-            $content_lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-        }
 
-        if (!$content_lines) {
-            $content_lines = array();
-        }
-        if (file_exists($file_bck)) {
-            $content_lines_bck = file($file_bck, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-            $content_lines = array_diff($content_lines, $content_lines_bck);
-        }
-        $content_lines = array_merge($content_lines, $this->shadow);
-        $content = implode("\n", $content_lines);
-        $content_bck = implode("\n", $this->shadow);
-
-        $this->write_file($file_bck, $content_bck);
-        return $this->write_file($file, $content);
+        return $this->write_content($file, $file_bck, $this->shadow);
     }
 
     protected function write_file($file, $content, $separator = "\n")

--- a/src/usr/share/alternc/panel/class/m_nss.php
+++ b/src/usr/share/alternc/panel/class/m_nss.php
@@ -101,8 +101,8 @@ class m_nss
         $content = implode("\n",$content_lines);
         $content_bck = implode("\n",$this->group);
 
-        file_put_contents($file_bck,$content_bck);
-        return file_put_contents($file, $content, LOCK_EX);
+        $this->write_file($file_bck,$content_bck);
+        return $this->write_file($file, $content);
     }
 
     protected function update_passwd_file()
@@ -122,8 +122,8 @@ class m_nss
         $content = implode("\n",$content_lines);
         $content_bck = implode("\n",$this->passwd);
 
-        file_put_contents($file_bck,$content_bck);
-        return file_put_contents($file, $content, LOCK_EX);
+        $this->write_file($file_bck,$content_bck);
+        return $this->write_file($file, $content);
     }
 
     protected function update_shadow_file()
@@ -143,7 +143,15 @@ class m_nss
         $content = implode("\n",$content_lines);
         $content_bck = implode("\n",$this->shadow);
 
-        file_put_contents($file_bck,$content_bck);
+        $this->write_file($file_bck,$content_bck);
+        return $this->write_file($file, $content);
+    }
+
+    protected function write_file($file,$content,$separator = "\n") {
+
+        if (is_array($content)) {
+            $content = implode($separator,$content);
+        }
         return file_put_contents($file, $content, LOCK_EX);
     }
 

--- a/src/usr/share/alternc/panel/class/m_nss.php
+++ b/src/usr/share/alternc/panel/class/m_nss.php
@@ -36,9 +36,9 @@ class m_nss
     {
         global $db;
         $db->query("SELECT login,uid FROM `membres`");
-        $lines=array();
+        $lines = array();
         while ($db->next_record()) {
-            $lines[] = $db->f('login').":x:".$db->f('uid').":";
+            $lines[] = $db->f('login') . ":x:" . $db->f('uid') . ":";
         }
 
         $this->group = $lines;
@@ -48,9 +48,9 @@ class m_nss
     {
         global $db;
         $db->query("SELECT login,uid FROM `membres`");
-        $lines=array();
+        $lines = array();
         while ($db->next_record()) {
-            $lines[] = $db->f('login').":x:".$db->f('uid').":".$db->f('uid')."::".getuserpath($db->f('login')).":/bin/false";
+            $lines[] = $db->f('login') . ":x:" . $db->f('uid') . ":" . $db->f('uid') . "::" . getuserpath($db->f('login')) . ":/bin/false";
         }
 
         $this->passwd = $lines;
@@ -60,19 +60,19 @@ class m_nss
     {
         global $db;
         $db->query("SELECT login FROM `membres`");
-        $lines=array();
+        $lines = array();
         while ($db->next_record()) {
-	    // shadow fields (9) :
-	    // 1. login
-	    // 2. encrypted password or * to prevent login
-	    // 3. date of last password change or '' meaning that password aging features are disabled
-	    // 4. minimum password age or '' or 0 meaning no minimum age
-	    // 5. maximum password age or '' meaning no maximum password age, no password warning period, and no password inactivity period
-	    // 6. password warning period or '' or 0 meaning there are no password warning period
-	    // 7. password inactivity period or '' for no enforcement
-	    // 8. account expiration date or '' for no expiration
-	    // 9. reserved
-	    $fields = array($db->f('login'), '*', '', '', '', '', '', '', '');
+            // shadow fields (9) :
+            // 1. login
+            // 2. encrypted password or * to prevent login
+            // 3. date of last password change or '' meaning that password aging features are disabled
+            // 4. minimum password age or '' or 0 meaning no minimum age
+            // 5. maximum password age or '' meaning no maximum password age, no password warning period, and no password inactivity period
+            // 6. password warning period or '' or 0 meaning there are no password warning period
+            // 7. password inactivity period or '' for no enforcement
+            // 8. account expiration date or '' for no expiration
+            // 9. reserved
+            $fields = array($db->f('login'), '*', '', '', '', '', '', '', '');
             $lines[] = implode(':', $fields);
         }
 
@@ -90,32 +90,32 @@ class m_nss
 
     protected function update_group_file()
     {
-        $file = $this->dir_extrausers."group";
-        $file_bck = $this->dir_backup."group";
+        $file = $this->dir_extrausers . "group";
+        $file_bck = $this->dir_backup . "group";
         $content_lines = false;
         if (file_exists($file)) {
             $content_lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
         }
 
         if (!$content_lines) {
-            $content_lines=[];
+            $content_lines = [];
         }
         if (file_exists($file_bck)) {
             $content_lines_bck = file($file_bck, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-            $content_lines = array_diff($content_lines,$content_lines_bck);
+            $content_lines = array_diff($content_lines, $content_lines_bck);
         }
-        $content_lines = array_merge($content_lines,$this->group);
-        $content = implode("\n",$content_lines);
-        $content_bck = implode("\n",$this->group);
+        $content_lines = array_merge($content_lines, $this->group);
+        $content = implode("\n", $content_lines);
+        $content_bck = implode("\n", $this->group);
 
-        $this->write_file($file_bck,$content_bck);
+        $this->write_file($file_bck, $content_bck);
         return $this->write_file($file, $content);
     }
 
     protected function update_passwd_file()
     {
-        $file = $this->dir_extrausers."passwd";
-        $file_bck = $this->dir_backup."passwd";
+        $file = $this->dir_extrausers . "passwd";
+        $file_bck = $this->dir_backup . "passwd";
         $content_lines = false;
         if (file_exists($file)) {
             $content_lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
@@ -126,20 +126,20 @@ class m_nss
         }
         if (file_exists($file_bck)) {
             $content_lines_bck = file($file_bck, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-            $content_lines = array_diff($content_lines,$content_lines_bck);
+            $content_lines = array_diff($content_lines, $content_lines_bck);
         }
-        $content_lines = array_merge($content_lines,$this->passwd);
-        $content = implode("\n",$content_lines);
-        $content_bck = implode("\n",$this->passwd);
+        $content_lines = array_merge($content_lines, $this->passwd);
+        $content = implode("\n", $content_lines);
+        $content_bck = implode("\n", $this->passwd);
 
-        $this->write_file($file_bck,$content_bck);
+        $this->write_file($file_bck, $content_bck);
         return $this->write_file($file, $content);
     }
 
     protected function update_shadow_file()
     {
-        $file = $this->dir_extrausers."shadow";
-        $file_bck = $this->dir_backup."shadow";
+        $file = $this->dir_extrausers . "shadow";
+        $file_bck = $this->dir_backup . "shadow";
         $content_lines = false;
         if (file_exists($file)) {
             $content_lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
@@ -150,20 +150,20 @@ class m_nss
         }
         if (file_exists($file_bck)) {
             $content_lines_bck = file($file_bck, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-            $content_lines = array_diff($content_lines,$content_lines_bck);
+            $content_lines = array_diff($content_lines, $content_lines_bck);
         }
-        $content_lines = array_merge($content_lines,$this->shadow);
-        $content = implode("\n",$content_lines);
-        $content_bck = implode("\n",$this->shadow);
+        $content_lines = array_merge($content_lines, $this->shadow);
+        $content = implode("\n", $content_lines);
+        $content_bck = implode("\n", $this->shadow);
 
-        $this->write_file($file_bck,$content_bck);
+        $this->write_file($file_bck, $content_bck);
         return $this->write_file($file, $content);
     }
 
-    protected function write_file($file,$content,$separator = "\n") {
-
+    protected function write_file($file, $content, $separator = "\n")
+    {
         if (is_array($content)) {
-            $content = implode($separator,$content);
+            $content = implode($separator, $content);
         }
         return file_put_contents($file, $content, LOCK_EX);
     }
@@ -174,4 +174,3 @@ class m_nss
         return true;
     }
 }
-

--- a/src/usr/share/alternc/panel/class/m_nss.php
+++ b/src/usr/share/alternc/panel/class/m_nss.php
@@ -33,11 +33,9 @@ class m_nss
         global $db;
         $db->query("SELECT login,uid FROM `membres`");
         $lines=array();
-        $lines[]='##ALTERNC ACCOUNTS START##';
         while ($db->next_record()) {
             $lines[] = $db->f('login').":x:".$db->f('uid').":";
         }
-        $lines[]='##ALTERNC ACCOUNTS END##';
 
         $this->group_file = implode("\n", $lines);
     }
@@ -47,11 +45,9 @@ class m_nss
         global $db;
         $db->query("SELECT login,uid FROM `membres`");
         $lines=array();
-        $lines[]='##ALTERNC ACCOUNTS START##';
         while ($db->next_record()) {
             $lines[] = $db->f('login').":x:".$db->f('uid').":".$db->f('uid')."::".getuserpath($db->f('login')).":/bin/false";
         }
-        $lines[]='##ALTERNC ACCOUNTS END##';
 
         $this->passwd_file = implode("\n", $lines);
     }
@@ -61,7 +57,6 @@ class m_nss
         global $db;
         $db->query("SELECT login FROM `membres`");
         $lines=array();
-        $lines[]='##ALTERNC ACCOUNTS START##';
         while ($db->next_record()) {
 	    // shadow fields (9) :
 	    // 1. login
@@ -76,7 +71,6 @@ class m_nss
 	    $fields = array($db->f('login'), '*', '', '', '', '', '', '', '');
             $lines[] = implode(':', $fields);
         }
-        $lines[]='##ALTERNC ACCOUNTS END##';
 
         $this->shadow_file = implode("\n", $lines);
     }
@@ -93,35 +87,24 @@ class m_nss
     protected function update_group_file()
     {
         $file = "/var/lib/extrausers/group";
-        $content = file_get_contents($file);
-        $content = preg_replace('/##ALTERNC ACCOUNTS START##.*##ALTERNC ACCOUNTS END##/ms', $this->group_file, $content, -1, $count);
-        if ($count == 0) {
-            $content .= $this->group_file;
-        }
+        // $content = file_get_contents($file);
+        $content .= $this->group_file;
         return file_put_contents($file, $content, LOCK_EX);
     }
 
     protected function update_passwd_file()
     {
         $file = "/var/lib/extrausers/passwd";
-        $content = file_get_contents($file);
-        $content = preg_replace('/##ALTERNC ACCOUNTS START##.*##ALTERNC ACCOUNTS END##/ms', $this->passwd_file, $content, -1, $count);
-        if ($count == 0) {
-            $content .= $this->passwd_file;
-        }
-
+        // $content = file_get_contents($file);
+        $content .= $this->passwd_file;
         return file_put_contents($file, $content, LOCK_EX);
     }
 
     protected function update_shadow_file()
     {
         $file = "/var/lib/extrausers/shadow";
-        $content = file_get_contents($file);
-        $content = preg_replace('/##ALTERNC ACCOUNTS START##.*##ALTERNC ACCOUNTS END##/ms', $this->shadow_file, $content, -1, $count);
-        if ($count == 0) {
-            $content .= $this->shadow_file;
-        }
-
+        // $content = file_get_contents($file);
+        $content .= $this->shadow_file;
         return file_put_contents($file, $content, LOCK_EX);
     }
 

--- a/src/usr/share/alternc/panel/class/m_nss.php
+++ b/src/usr/share/alternc/panel/class/m_nss.php
@@ -9,6 +9,9 @@ class m_nss
     protected $passwd = array();
     protected $shadow = array();
 
+    protected $dir_backup = "/var/lib/alternc/backups/";
+    protected $dir_extrausers = "/var/lib/extrausers/";
+
     /** Hook function called when a user is created
      * This function add acccount to nss file
      * globals $cuid is the appropriate user
@@ -87,8 +90,8 @@ class m_nss
 
     protected function update_group_file()
     {
-        $file = "/var/lib/extrausers/group";
-        $file_bck = "/var/lib/alternc/backups/group";
+        $file = $this->dir_extrausers."group";
+        $file_bck = $this->dir_backup."group";
         $content_lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
 
         if (!$content_lines) {
@@ -108,8 +111,8 @@ class m_nss
 
     protected function update_passwd_file()
     {
-        $file = "/var/lib/extrausers/passwd";
-        $file_bck = "/var/lib/alternc/backups/passwd";
+        $file = $this->dir_extrausers."passwd";
+        $file_bck = $this->dir_backup."passwd";
         $content_lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
 
         if (!$content_lines) {
@@ -129,8 +132,8 @@ class m_nss
 
     protected function update_shadow_file()
     {
-        $file = "/var/lib/extrausers/shadow";
-        $file_bck = "/var/lib/alternc/backups/shadow";
+        $file = $this->dir_extrausers."shadow";
+        $file_bck = $this->dir_backup."shadow";
         $content_lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
 
         if (!$content_lines) {

--- a/src/usr/share/alternc/panel/class/m_nss.php
+++ b/src/usr/share/alternc/panel/class/m_nss.php
@@ -95,7 +95,7 @@ class m_nss
         }
         $content_lines = array_merge($content_lines, $content_new);
         $content = implode("\n", $content_lines);
-        $content_bck = implode("\n", $this->group);
+        $content_bck = implode("\n", $content_new);
 
         return $this->write_file($file_bck, $content_bck) && $this->write_file($file, $content);
     }

--- a/src/usr/share/alternc/panel/class/m_nss.php
+++ b/src/usr/share/alternc/panel/class/m_nss.php
@@ -88,10 +88,18 @@ class m_nss
     {
         $file = "/var/lib/extrausers/group";
         $file_bck = "/var/lib/alternc/backups/group";
-        if (!file_exists($file_bck)) {
-            $content = file_get_contents($file);
-            $content .= $this->group_file;
+        $content = "";
+
+        $content_lines = file($file);
+        if (!$content_lines) {
+            $content_lines=[];
         }
+        if (file_exists($file_bck)) {
+            $content_lines_bck = file($file_bck);
+            $content_lines = array_diff($content_lines,$content_lines_bck);
+            $content = implode("\n", $content_lines);
+        }
+        $content .= $this->group_file;
         file_put_contents($file_bck,$this->group_file);
         return file_put_contents($file, $content, LOCK_EX);
     }
@@ -100,10 +108,18 @@ class m_nss
     {
         $file = "/var/lib/extrausers/passwd";
         $file_bck = "/var/lib/alternc/backups/passwd";
-        if (!file_exists($file_bck)) {
-            $content = file_get_contents($file);
-            $content .= $this->passwd_file;
+        $content = "";
+
+        $content_lines = file($file);
+        if (!$content_lines) {
+            $content_lines=[];
         }
+        if (file_exists($file_bck)) {
+            $content_lines_bck = file($file_bck);
+            $content_lines = array_diff($content_lines,$content_lines_bck);
+            $content = implode("\n", $content_lines);
+        }
+        $content .= $this->passwd_file;
         file_put_contents($file_bck,$this->passwd_file);
         return file_put_contents($file, $content, LOCK_EX);
     }
@@ -112,10 +128,18 @@ class m_nss
     {
         $file = "/var/lib/extrausers/shadow";
         $file_bck = "/var/lib/alternc/backups/shadow";
-        if (!file_exists($file_bck)) {
-            $content = file_get_contents($file);
-            $content .= $this->shadow_file;
+        $content = "";
+
+        $content_lines = file($file);
+        if (!$content_lines) {
+            $content_lines=[];
         }
+        if (file_exists($file_bck)) {
+            $content_lines_bck = file($file_bck);
+            $content_lines = array_diff($content_lines,$content_lines_bck);
+            $content = implode("\n", $content_lines);
+        }
+        $content .= $this->shadow_file;
         file_put_contents($file_bck,$this->shadow_file);
         return file_put_contents($file, $content, LOCK_EX);
     }

--- a/src/usr/share/alternc/panel/class/m_nss.php
+++ b/src/usr/share/alternc/panel/class/m_nss.php
@@ -5,9 +5,10 @@
  */
 class m_nss
 {
-    protected $group;
-    protected $passwd;
-    protected $shadow;
+    protected $group = array();
+    protected $passwd = array();
+    protected $shadow = array();
+
     /** Hook function called when a user is created
      * This function add acccount to nss file
      * globals $cuid is the appropriate user

--- a/src/usr/share/alternc/panel/class/m_nss.php
+++ b/src/usr/share/alternc/panel/class/m_nss.php
@@ -92,7 +92,10 @@ class m_nss
     {
         $file = $this->dir_extrausers."group";
         $file_bck = $this->dir_backup."group";
-        $content_lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        $content_lines = false;
+        if (file_exists($file)) {
+            $content_lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        }
 
         if (!$content_lines) {
             $content_lines=[];
@@ -113,7 +116,10 @@ class m_nss
     {
         $file = $this->dir_extrausers."passwd";
         $file_bck = $this->dir_backup."passwd";
-        $content_lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        $content_lines = false;
+        if (file_exists($file)) {
+            $content_lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        }
 
         if (!$content_lines) {
             $content_lines = array();
@@ -134,7 +140,10 @@ class m_nss
     {
         $file = $this->dir_extrausers."shadow";
         $file_bck = $this->dir_backup."shadow";
-        $content_lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        $content_lines = false;
+        if (file_exists($file)) {
+            $content_lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        }
 
         if (!$content_lines) {
             $content_lines = array();

--- a/src/usr/share/alternc/panel/class/m_nss.php
+++ b/src/usr/share/alternc/panel/class/m_nss.php
@@ -5,9 +5,9 @@
  */
 class m_nss
 {
-    protected $group_file;
-    protected $passwd_file;
-    protected $shadow_file;
+    protected $group;
+    protected $passwd;
+    protected $shadow;
     /** Hook function called when a user is created
      * This function add acccount to nss file
      * globals $cuid is the appropriate user
@@ -37,7 +37,7 @@ class m_nss
             $lines[] = $db->f('login').":x:".$db->f('uid').":";
         }
 
-        $this->group_file = implode("\n", $lines);
+        $this->group = $lines;
     }
 
     protected function define_passwd_file()
@@ -49,7 +49,7 @@ class m_nss
             $lines[] = $db->f('login').":x:".$db->f('uid').":".$db->f('uid')."::".getuserpath($db->f('login')).":/bin/false";
         }
 
-        $this->passwd_file = implode("\n", $lines);
+        $this->passwd = $lines;
     }
 
     protected function define_shadow_file()
@@ -72,7 +72,7 @@ class m_nss
             $lines[] = implode(':', $fields);
         }
 
-        $this->shadow_file = implode("\n", $lines);
+        $this->shadow = $lines;
     }
 
     public function update_files()
@@ -88,19 +88,20 @@ class m_nss
     {
         $file = "/var/lib/extrausers/group";
         $file_bck = "/var/lib/alternc/backups/group";
-        $content = "";
-
         $content_lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+
         if (!$content_lines) {
             $content_lines=[];
         }
         if (file_exists($file_bck)) {
             $content_lines_bck = file($file_bck, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
             $content_lines = array_diff($content_lines,$content_lines_bck);
-            $content = implode("\n", $content_lines);
         }
-        $content .= $this->group_file;
-        file_put_contents($file_bck,$this->group_file);
+        $content_lines = array_merge($content_lines,$this->group);
+        $content = implode("\n",$content_lines);
+        $content_bck = implode("\n",$this->group);
+
+        file_put_contents($file_bck,$content_bck);
         return file_put_contents($file, $content, LOCK_EX);
     }
 
@@ -108,19 +109,20 @@ class m_nss
     {
         $file = "/var/lib/extrausers/passwd";
         $file_bck = "/var/lib/alternc/backups/passwd";
-        $content = "";
-
         $content_lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+
         if (!$content_lines) {
-            $content_lines=[];
+            $content_lines = array();
         }
         if (file_exists($file_bck)) {
             $content_lines_bck = file($file_bck, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
             $content_lines = array_diff($content_lines,$content_lines_bck);
-            $content = implode("\n", $content_lines);
         }
-        $content .= $this->passwd_file;
-        file_put_contents($file_bck,$this->passwd_file);
+        $content_lines = array_merge($content_lines,$this->passwd);
+        $content = implode("\n",$content_lines);
+        $content_bck = implode("\n",$this->passwd);
+
+        file_put_contents($file_bck,$content_bck);
         return file_put_contents($file, $content, LOCK_EX);
     }
 
@@ -128,19 +130,20 @@ class m_nss
     {
         $file = "/var/lib/extrausers/shadow";
         $file_bck = "/var/lib/alternc/backups/shadow";
-        $content = "";
-
         $content_lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+
         if (!$content_lines) {
-            $content_lines=[];
+            $content_lines = array();
         }
         if (file_exists($file_bck)) {
             $content_lines_bck = file($file_bck, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
             $content_lines = array_diff($content_lines,$content_lines_bck);
-            $content = implode("\n", $content_lines);
         }
-        $content .= $this->shadow_file;
-        file_put_contents($file_bck,$this->shadow_file);
+        $content_lines = array_merge($content_lines,$this->shadow);
+        $content = implode("\n",$content_lines);
+        $content_bck = implode("\n",$this->shadow);
+
+        file_put_contents($file_bck,$content_bck);
         return file_put_contents($file, $content, LOCK_EX);
     }
 

--- a/src/usr/share/alternc/panel/class/m_nss.php
+++ b/src/usr/share/alternc/panel/class/m_nss.php
@@ -87,24 +87,21 @@ class m_nss
     protected function update_group_file()
     {
         $file = "/var/lib/extrausers/group";
-        // $content = file_get_contents($file);
-        $content .= $this->group_file;
+        $content = $this->group_file;
         return file_put_contents($file, $content, LOCK_EX);
     }
 
     protected function update_passwd_file()
     {
         $file = "/var/lib/extrausers/passwd";
-        // $content = file_get_contents($file);
-        $content .= $this->passwd_file;
+        $content = $this->passwd_file;
         return file_put_contents($file, $content, LOCK_EX);
     }
 
     protected function update_shadow_file()
     {
         $file = "/var/lib/extrausers/shadow";
-        // $content = file_get_contents($file);
-        $content .= $this->shadow_file;
+        $content = $this->shadow_file;
         return file_put_contents($file, $content, LOCK_EX);
     }
 

--- a/src/usr/share/alternc/panel/class/m_nss.php
+++ b/src/usr/share/alternc/panel/class/m_nss.php
@@ -90,12 +90,12 @@ class m_nss
         $file_bck = "/var/lib/alternc/backups/group";
         $content = "";
 
-        $content_lines = file($file);
+        $content_lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
         if (!$content_lines) {
             $content_lines=[];
         }
         if (file_exists($file_bck)) {
-            $content_lines_bck = file($file_bck);
+            $content_lines_bck = file($file_bck, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
             $content_lines = array_diff($content_lines,$content_lines_bck);
             $content = implode("\n", $content_lines);
         }
@@ -110,12 +110,12 @@ class m_nss
         $file_bck = "/var/lib/alternc/backups/passwd";
         $content = "";
 
-        $content_lines = file($file);
+        $content_lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
         if (!$content_lines) {
             $content_lines=[];
         }
         if (file_exists($file_bck)) {
-            $content_lines_bck = file($file_bck);
+            $content_lines_bck = file($file_bck, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
             $content_lines = array_diff($content_lines,$content_lines_bck);
             $content = implode("\n", $content_lines);
         }
@@ -130,12 +130,12 @@ class m_nss
         $file_bck = "/var/lib/alternc/backups/shadow";
         $content = "";
 
-        $content_lines = file($file);
+        $content_lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
         if (!$content_lines) {
             $content_lines=[];
         }
         if (file_exists($file_bck)) {
-            $content_lines_bck = file($file_bck);
+            $content_lines_bck = file($file_bck, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
             $content_lines = array_diff($content_lines,$content_lines_bck);
             $content = implode("\n", $content_lines);
         }

--- a/src/usr/share/alternc/panel/class/m_nss.php
+++ b/src/usr/share/alternc/panel/class/m_nss.php
@@ -87,21 +87,36 @@ class m_nss
     protected function update_group_file()
     {
         $file = "/var/lib/extrausers/group";
-        $content = $this->group_file;
+        $file_bck = "/var/lib/alternc/backups/group";
+        if (!file_exists($file_bck)) {
+            $content = file_get_contents($file);
+            $content .= $this->group_file;
+        }
+        file_put_contents($file_bck,$this->group_file);
         return file_put_contents($file, $content, LOCK_EX);
     }
 
     protected function update_passwd_file()
     {
         $file = "/var/lib/extrausers/passwd";
-        $content = $this->passwd_file;
+        $file_bck = "/var/lib/alternc/backups/passwd";
+        if (!file_exists($file_bck)) {
+            $content = file_get_contents($file);
+            $content .= $this->passwd_file;
+        }
+        file_put_contents($file_bck,$this->passwd_file);
         return file_put_contents($file, $content, LOCK_EX);
     }
 
     protected function update_shadow_file()
     {
         $file = "/var/lib/extrausers/shadow";
-        $content = $this->shadow_file;
+        $file_bck = "/var/lib/alternc/backups/shadow";
+        if (!file_exists($file_bck)) {
+            $content = file_get_contents($file);
+            $content .= $this->shadow_file;
+        }
+        file_put_contents($file_bck,$this->shadow_file);
         return file_put_contents($file, $content, LOCK_EX);
     }
 

--- a/src/usr/share/alternc/panel/class/m_nss.php
+++ b/src/usr/share/alternc/panel/class/m_nss.php
@@ -97,6 +97,9 @@ class m_nss
         $content = implode("\n", $content_lines);
         $content_bck = implode("\n", $content_new);
 
+        //Provide a final return carrier
+        $content .= "\n";
+
         return $this->write_file($file_bck, $content_bck) && $this->write_file($file, $content);
     }
 


### PR DESCRIPTION
* On (more or less) huge passwd/shadow file OOM could occured
* lib nss doesn't support comments in these file

cf #10 